### PR TITLE
Fixes rtw_memcpy warnings

### DIFF
--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9819,7 +9819,11 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		rtw_hal_read_chip_info(padapter);
 		/* set mac addr*/
 		rtw_macaddr_cfg(adapter_mac_addr(padapter), get_hal_mac_addr(padapter));
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 		_rtw_memcpy(padapter->pnetdev->dev_addr, get_hal_mac_addr(padapter), ETH_ALEN); /* set mac addr to net_device */
+#else
+		dev_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter)); /* set mac addr to net_device */
+#endif
 
 #ifdef CONFIG_P2P
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2538,7 +2538,11 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	_rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+#else
+	dev_addr_set(pnetdev, adapter_mac_addr(padapter));
+#endif
 
 	if (rtnl_lock_needed)
 		ret = register_netdev(pnetdev);


### PR DESCRIPTION
Fixes some rtw_memcpy warnings on following files
ioctl_linux.c
osdep_service.c